### PR TITLE
Make sub-sprites first class

### DIFF
--- a/platform/Sprite.roc
+++ b/platform/Sprite.roc
@@ -83,7 +83,7 @@ blit = \@Sprite { data, bpp, stride, region }, { x, y, flags ? [] } ->
 ## ```
 ##
 ## Note: If your program should never generate an invalid subregion,
-## [subOrCrash] is enables avoiding the result and simpler code.
+## [subOrCrash] enables avoiding the result and simpler code.
 ##
 sub : Sprite, SubRegion -> Result Sprite [OutOfBounds]
 sub = \@Sprite sprite, subRegion ->
@@ -107,7 +107,7 @@ sub = \@Sprite sprite, subRegion ->
 ## This is really useful for static sprite sheet data that needs subSprites extracted.
 ##
 ## ```
-## subSpriteResult = Sprite.sub sprite { srcX: 20, srcY: 0, width: 20, height: 20 }
+## subSprite = Sprite.subOrCrash sprite { srcX: 20, srcY: 0, width: 20, height: 20 }
 ## ```
 ##
 ## Warning: Will crash if the subregion is not contained within the sprite.


### PR DESCRIPTION
This makes using a sprite sheet much much nicer.
Just extract N sub-sprites from the sheet and use them exactly like normal sprites. No need to deal with with a separate `blitSub` method or doing the math in many places.

Makes animations in rocci-bird from a sprite sheet a lot cleaner overall.