### PR TITLE
Make zeroing memory optional

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,6 +9,10 @@ pub fn build(b: *std.Build) !void {
     // Luckily, end users can set this manually when building.
     const mem_size = b.option(u16, "mem-size", "the amount of space reserved for dynamic memory allocation") orelse 40960;
 
+    // Enable this if you hit any sort of memory corruption.
+    // It will cost performance.
+    const zero_on_alloc = b.option(bool, "zero-on-alloc", "zeros all newly allocated memory") orelse false;
+
     const roc_check = b.addSystemCommand(&[_][]const u8{ "roc", "check" });
     const roc_lib = b.addSystemCommand(&[_][]const u8{ "roc", "build", "--target=wasm32", "--no-link", "--output", "zig-cache/app.o" });
     // By setting this to true, we ensure zig always rebuilds the roc app since it can't tell if any transitive dependencies have changed.
@@ -46,6 +50,7 @@ pub fn build(b: *std.Build) !void {
     });
     const options = b.addOptions();
     options.addOption(usize, "mem_size", mem_size);
+    options.addOption(bool, "zero_on_alloc", zero_on_alloc);
     lib.addOptions("config", options);
 
     lib.import_memory = true;

--- a/platform/host.zig
+++ b/platform/host.zig
@@ -72,13 +72,15 @@ export fn roc_alloc(requested_size: usize, alignment: u32) callconv(.C) *anyopaq
 
     const data_ptr: [*]usize = @ptrFromInt(data_addr);
 
-    // Zero all memory before passing to Roc.
-    var i: usize = 0;
-    while (i < (chunk_size - MEM_CHUNK_SIZE) / MEM_CHUNK_SIZE) : (i += 1) {
-        const usizes = MEM_CHUNK_SIZE / @sizeOf(usize);
-        comptime var j = 0;
-        inline while (j < usizes) : (j += 1) {
-            data_ptr[i * usizes + j] = 0;
+    if (config.zero_on_alloc) {
+        // Zero all memory before passing to Roc.
+        var i: usize = 0;
+        while (i < (chunk_size - MEM_CHUNK_SIZE) / MEM_CHUNK_SIZE) : (i += 1) {
+            const usizes = MEM_CHUNK_SIZE / @sizeOf(usize);
+            comptime var j = 0;
+            inline while (j < usizes) : (j += 1) {
+                data_ptr[i * usizes + j] = 0;
+            }
         }
     }
 


### PR DESCRIPTION
Turns now that the other memory bugs are fixed that this doesn't seemed to be needed. In case I am wrong, I made a config to re-enable it. That way if an end user hits memory corruption, they can just turn on the flag.