### PR TITLE
Update for Zig 0.12

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -16,9 +16,9 @@ pub fn build(b: *std.Build) !void {
 
     const build_roc = b.addExecutable(.{
         .name = "build_roc",
-        .root_source_file = .{ .path = "build_roc.zig" },
+        .root_source_file = b.path("build_roc.zig"),
         // Empty means native.
-        .target = .{},
+        .target = b.graph.host,
         .optimize = .Debug,
     });
     const run_build_roc = b.addRunArtifact(build_roc);
@@ -27,10 +27,10 @@ pub fn build(b: *std.Build) !void {
     run_build_roc.has_side_effects = true;
 
     if (roc_src) |val| {
-        run_build_roc.addFileArg(.{ .path = val });
+        run_build_roc.addFileArg(b.path(val));
     } else {
         const default_path = "examples/snake.roc";
-        run_build_roc.addFileArg(.{ .path = default_path });
+        run_build_roc.addFileArg(b.path(default_path));
     }
 
     switch (optimize) {
@@ -44,17 +44,20 @@ pub fn build(b: *std.Build) !void {
     }
 
     // TODO: change to addExecutable with entry disabled when we update to zig 0.12.0.
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addExecutable(.{
         .name = "cart",
-        .root_source_file = .{ .path = "platform/host.zig" },
-        .target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding },
+        .root_source_file = b.path("platform/host.zig"),
+        .target = b.resolveTargetQuery(.{
+            .cpu_arch = .wasm32,
+            .os_tag = .freestanding,
+        }),
         .optimize = optimize,
     });
     const options = b.addOptions();
     options.addOption(usize, "mem_size", mem_size);
     options.addOption(bool, "zero_on_alloc", zero_on_alloc);
     options.addOption(bool, "trace_allocs", trace_allocs);
-    lib.addOptions("config", options);
+    lib.root_module.addOptions("config", options);
 
     lib.import_memory = true;
     lib.initial_memory = 65536;
@@ -62,10 +65,10 @@ pub fn build(b: *std.Build) !void {
     lib.stack_size = 14752;
 
     // Export WASM-4 symbols
-    lib.export_symbol_names = &[_][]const u8{ "start", "update" };
+    lib.root_module.export_symbol_names = &[_][]const u8{ "start", "update" };
 
     lib.step.dependOn(&run_build_roc.step);
-    lib.addObjectFile(.{ .path = "zig-cache/app.o" });
+    lib.addObjectFile(b.path("zig-cache/app.o"));
 
     b.installArtifact(lib);
 

--- a/build.zig
+++ b/build.zig
@@ -59,6 +59,7 @@ pub fn build(b: *std.Build) !void {
     options.addOption(bool, "trace_allocs", trace_allocs);
     lib.root_module.addOptions("config", options);
 
+    lib.entry = .disabled;
     lib.import_memory = true;
     lib.initial_memory = 65536;
     lib.max_memory = 65536;

--- a/build_roc.zig
+++ b/build_roc.zig
@@ -28,7 +28,7 @@ pub fn main() !void {
 
     // Run `roc check`
     const roc_check_args = [_][]const u8{ "roc", "check", app_name };
-    var roc_check = try std.ChildProcess.exec(.{
+    const roc_check = try std.process.Child.run(.{
         .allocator = allocator,
         .argv = &roc_check_args,
     });
@@ -53,7 +53,7 @@ pub fn main() !void {
         try roc_build_args.append(optimize_flag);
     }
     try roc_build_args.append(app_name);
-    var roc_build = try std.ChildProcess.exec(.{
+    const roc_build = try std.process.Child.run(.{
         .allocator = allocator,
         .argv = roc_build_args.items,
     });

--- a/platform/InternalTask.roc
+++ b/platform/InternalTask.roc
@@ -1,6 +1,6 @@
-interface InternalTask
-    exposes [Task, fromEffect, toEffect, ok, err]
-    imports [Effect.{ Effect }]
+module [Task, fromEffect, toEffect, ok, err]
+
+import Effect exposing [Effect]
 
 Task ok err := Effect (Result ok err)
 

--- a/platform/Sprite.roc
+++ b/platform/Sprite.roc
@@ -1,6 +1,8 @@
-interface Sprite
-    exposes [Sprite, SubRegion, new, blit, sub, subOrCrash]
-    imports [InternalTask, Task.{ Task }, Effect.{ Effect }]
+module [Sprite, SubRegion, new, blit, sub, subOrCrash]
+
+import InternalTask
+import Task exposing [Task]
+import Effect
 
 ## Represents a [sprite](https://en.wikipedia.org/wiki/Sprite_(computer_graphics)) for drawing to the screen.
 ##

--- a/platform/Task.roc
+++ b/platform/Task.roc
@@ -1,20 +1,21 @@
-interface Task
-    exposes [
-        Task,
-        ok,
-        err,
-        await,
-        map,
-        mapErr,
-        onErr,
-        attempt,
-        forever,
-        loop,
-        fromResult,
-        batch,
-        result,
-    ]
-    imports [Effect, InternalTask]
+module [
+    Task,
+    ok,
+    err,
+    await,
+    map,
+    mapErr,
+    onErr,
+    attempt,
+    forever,
+    loop,
+    fromResult,
+    batch,
+    result,
+]
+
+import Effect
+import InternalTask
 
 ## A Task represents an effect; an interaction with state outside your Roc
 ## program, such as the terminal's standard output, or a file.

--- a/platform/W4.roc
+++ b/platform/W4.roc
@@ -2,49 +2,51 @@
 ##
 ## Build [wasm4](https://wasm4.org) games using Roc
 ##
-interface W4
-    exposes [
-        Palette,
-        Mouse,
-        Gamepad,
-        Netplay,
-        Player,
-        Shader,
-        screenWidth,
-        screenHeight,
-        text,
-        setPalette,
-        getPalette,
-        setDrawColors,
-        getDrawColors,
-        setPrimaryColor,
-        setTextColors,
-        setShapeColors,
-        getGamepad,
-        getMouse,
-        getNetplay,
-        rect,
-        oval,
-        line,
-        hline,
-        vline,
-        seedRand,
-        rand,
-        randBetween,
-        trace,
-        debug,
-        saveToDisk,
-        loadFromDisk,
-        preserveFrameBuffer,
-        clearFrameBufferEachUpdate,
-        hideGamepadOverlay,
-        showGamepadOverlay,
-        tone,
-        getPixel,
-        setPixel,
-        runShader,
-    ]
-    imports [InternalTask, Task.{ Task }, Effect.{ Effect }]
+module [
+    Palette,
+    Mouse,
+    Gamepad,
+    Netplay,
+    Player,
+    Shader,
+    screenWidth,
+    screenHeight,
+    text,
+    setPalette,
+    getPalette,
+    setDrawColors,
+    getDrawColors,
+    setPrimaryColor,
+    setTextColors,
+    setShapeColors,
+    getGamepad,
+    getMouse,
+    getNetplay,
+    rect,
+    oval,
+    line,
+    hline,
+    vline,
+    seedRand,
+    rand,
+    randBetween,
+    trace,
+    debug,
+    saveToDisk,
+    loadFromDisk,
+    preserveFrameBuffer,
+    clearFrameBufferEachUpdate,
+    hideGamepadOverlay,
+    showGamepadOverlay,
+    tone,
+    getPixel,
+    setPixel,
+    runShader,
+]
+
+import InternalTask
+import Task exposing [Task]
+import Effect
 
 ## The [Palette] consists of four colors. There is also `None` which is used to
 ## represent a transparent or no change color. Each pixel on the screen will be
@@ -810,4 +812,3 @@ expect
     res = fromColorFlags 0x0042
     res == { primary: Color2, secondary: Color4, tertiary: None, quaternary: None }
 expect fromColorFlags 0x4321 == { primary: Color1, secondary: Color2, tertiary: Color3, quaternary: Color4 }
-

--- a/platform/glue/list.zig
+++ b/platform/glue/list.zig
@@ -88,7 +88,7 @@ pub const RocList = extern struct {
             return RocList.empty();
         }
 
-        var list = allocate(@alignOf(T), slice.len, @sizeOf(T));
+        const list = allocate(@alignOf(T), slice.len, @sizeOf(T));
 
         if (slice.len > 0) {
             const dest = list.bytes orelse unreachable;
@@ -162,7 +162,7 @@ pub const RocList = extern struct {
         }
 
         // unfortunately, we have to clone
-        var new_list = RocList.allocate(alignment, self.length, element_width);
+        const new_list = RocList.allocate(alignment, self.length, element_width);
 
         var old_bytes: [*]u8 = @as([*]u8, @ptrCast(self.bytes));
         var new_bytes: [*]u8 = @as([*]u8, @ptrCast(new_list.bytes));
@@ -516,7 +516,7 @@ pub fn listReleaseExcessCapacity(
         list.decref(alignment);
         return RocList.empty();
     } else {
-        var output = RocList.allocateExact(alignment, old_length, element_width);
+        const output = RocList.allocateExact(alignment, old_length, element_width);
         if (list.bytes) |source_ptr| {
             const dest_ptr = output.bytes orelse unreachable;
 
@@ -844,7 +844,7 @@ fn swap(width_initial: usize, p1: [*]u8, p2: [*]u8) void {
     var ptr2 = p2;
 
     var buffer_actual: [threshold]u8 = undefined;
-    var buffer: [*]u8 = buffer_actual[0..];
+    const buffer: [*]u8 = buffer_actual[0..];
 
     while (true) {
         if (width < threshold) {
@@ -862,8 +862,8 @@ fn swap(width_initial: usize, p1: [*]u8, p2: [*]u8) void {
 }
 
 fn swapElements(source_ptr: [*]u8, element_width: usize, index_1: usize, index_2: usize) void {
-    var element_at_i = source_ptr + (index_1 * element_width);
-    var element_at_j = source_ptr + (index_2 * element_width);
+    const element_at_i = source_ptr + (index_1 * element_width);
+    const element_at_j = source_ptr + (index_2 * element_width);
 
     return swap(element_width, element_at_i, element_at_j);
 }
@@ -1018,7 +1018,7 @@ pub fn listAllocationPtr(
 
 test "listConcat: non-unique with unique overlapping" {
     var nonUnique = RocList.fromSlice(u8, ([_]u8{1})[0..]);
-    var bytes: [*]u8 = @as([*]u8, @ptrCast(nonUnique.bytes));
+    const bytes: [*]u8 = @as([*]u8, @ptrCast(nonUnique.bytes));
     const ptr_width = @sizeOf(usize);
     const refcount_ptr = @as([*]isize, @ptrCast(@as([*]align(ptr_width) u8, @alignCast(bytes)) - ptr_width));
     utils.increfRcPtrC(&refcount_ptr[0], 1);

--- a/platform/glue/str.zig
+++ b/platform/glue/str.zig
@@ -212,7 +212,7 @@ pub const RocStr = extern struct {
             // just return the bytes
             return str;
         } else {
-            var new_str = RocStr.allocateBig(str.length, str.length);
+            const new_str = RocStr.allocateBig(str.length, str.length);
 
             var old_bytes: [*]u8 = @as([*]u8, @ptrCast(str.bytes));
             var new_bytes: [*]u8 = @as([*]u8, @ptrCast(new_str.bytes));
@@ -273,7 +273,7 @@ pub const RocStr = extern struct {
             const source_ptr = self.asU8ptr();
             const dest_ptr = result.asU8ptrMut();
 
-            std.mem.copy(u8, dest_ptr[0..old_length], source_ptr[0..old_length]);
+            std.mem.copyForwards(u8, dest_ptr[0..old_length], source_ptr[0..old_length]);
             @memset(dest_ptr[old_length..new_length], 0);
 
             self.decref();
@@ -289,7 +289,7 @@ pub const RocStr = extern struct {
 
             const source_ptr = self.asU8ptr();
 
-            std.mem.copy(u8, dest_ptr[0..old_length], source_ptr[0..old_length]);
+            std.mem.copyForwards(u8, dest_ptr[0..old_length], source_ptr[0..old_length]);
             @memset(dest_ptr[old_length..new_length], 0);
 
             self.decref();
@@ -553,7 +553,7 @@ pub fn strNumberOfBytes(string: RocStr) callconv(.C) usize {
 
 // Str.fromInt
 pub fn exportFromInt(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(int: T) callconv(.C) RocStr {
             return @call(.always_inline, strFromIntHelp, .{ T, int });
         }
@@ -567,9 +567,9 @@ fn strFromIntHelp(comptime T: type, int: T) RocStr {
     const size = comptime blk: {
         // the string representation of the minimum i128 value uses at most 40 characters
         var buf: [40]u8 = undefined;
-        var resultMin = std.fmt.bufPrint(&buf, "{}", .{std.math.minInt(T)}) catch unreachable;
-        var resultMax = std.fmt.bufPrint(&buf, "{}", .{std.math.maxInt(T)}) catch unreachable;
-        var result = if (resultMin.len > resultMax.len) resultMin.len else resultMax.len;
+        const resultMin = std.fmt.bufPrint(&buf, "{}", .{std.math.minInt(T)}) catch unreachable;
+        const resultMax = std.fmt.bufPrint(&buf, "{}", .{std.math.maxInt(T)}) catch unreachable;
+        const result = if (resultMin.len > resultMax.len) resultMin.len else resultMax.len;
         break :blk result;
     };
 
@@ -581,7 +581,7 @@ fn strFromIntHelp(comptime T: type, int: T) RocStr {
 
 // Str.fromFloat
 pub fn exportFromFloat(comptime T: type, comptime name: []const u8) void {
-    comptime var f = struct {
+    const f = comptime struct {
         fn func(float: T) callconv(.C) RocStr {
             return @call(.always_inline, strFromFloatHelp, .{ T, float });
         }
@@ -661,7 +661,7 @@ test "strSplitHelp: empty delimiter" {
 
     strSplitHelp(array_ptr, str, delimiter);
 
-    var expected = [1]RocStr{
+    const expected = [1]RocStr{
         str,
     };
 
@@ -695,7 +695,7 @@ test "strSplitHelp: no delimiter" {
 
     strSplitHelp(array_ptr, str, delimiter);
 
-    var expected = [1]RocStr{
+    const expected = [1]RocStr{
         str,
     };
 
@@ -734,7 +734,7 @@ test "strSplitHelp: empty start" {
 
     const one = RocStr.init("a", 1);
 
-    var expected = [2]RocStr{
+    const expected = [2]RocStr{
         RocStr.empty(), one,
     };
 
@@ -776,7 +776,7 @@ test "strSplitHelp: empty end" {
     const one = RocStr.init("1", 1);
     const two = RocStr.init("2", 1);
 
-    var expected = [3]RocStr{
+    const expected = [3]RocStr{
         one, two, RocStr.empty(),
     };
 
@@ -812,7 +812,7 @@ test "strSplitHelp: string equals delimiter" {
 
     strSplitHelp(array_ptr, str_delimiter, str_delimiter);
 
-    var expected = [2]RocStr{ RocStr.empty(), RocStr.empty() };
+    const expected = [2]RocStr{ RocStr.empty(), RocStr.empty() };
 
     defer {
         for (array) |rocStr| {
@@ -850,7 +850,7 @@ test "strSplitHelp: delimiter on sides" {
     const ghi_arr = "ghi";
     const ghi = RocStr.init(ghi_arr, ghi_arr.len);
 
-    var expected = [3]RocStr{
+    const expected = [3]RocStr{
         RocStr.empty(), ghi, RocStr.empty(),
     };
 
@@ -891,7 +891,7 @@ test "strSplitHelp: three pieces" {
     const b = RocStr.init("b", 1);
     const c = RocStr.init("c", 1);
 
-    var expected_array = [array_len]RocStr{
+    const expected_array = [array_len]RocStr{
         a, b, c,
     };
 
@@ -927,7 +927,7 @@ test "strSplitHelp: overlapping delimiter 1" {
 
     strSplitHelp(array_ptr, str, delimiter);
 
-    var expected = [2]RocStr{
+    const expected = [2]RocStr{
         RocStr.empty(),
         RocStr.init("a", 1),
     };
@@ -952,7 +952,7 @@ test "strSplitHelp: overlapping delimiter 2" {
 
     strSplitHelp(array_ptr, str, delimiter);
 
-    var expected = [3]RocStr{
+    const expected = [3]RocStr{
         RocStr.empty(),
         RocStr.empty(),
         RocStr.empty(),
@@ -1363,7 +1363,7 @@ fn strJoinWith(list: RocListStr, separator: RocStr) RocStr {
         total_size += separator.len() * (len - 1);
 
         var result = RocStr.allocate(total_size);
-        var result_ptr = result.asU8ptrMut();
+        const result_ptr = result.asU8ptrMut();
 
         var offset: usize = 0;
         for (slice[0 .. len - 1]) |substr| {
@@ -1942,7 +1942,7 @@ pub fn strTrimEnd(input_string: RocStr) callconv(.C) RocStr {
 fn countLeadingWhitespaceBytes(string: RocStr) usize {
     var byte_count: usize = 0;
 
-    var bytes = string.asU8ptr()[0..string.len()];
+    const bytes = string.asU8ptr()[0..string.len()];
     var iter = unicode.Utf8View.initUnchecked(bytes).iterator();
     while (iter.nextCodepoint()) |codepoint| {
         if (isWhitespace(codepoint)) {
@@ -1958,7 +1958,7 @@ fn countLeadingWhitespaceBytes(string: RocStr) usize {
 fn countTrailingWhitespaceBytes(string: RocStr) usize {
     var byte_count: usize = 0;
 
-    var bytes = string.asU8ptr()[0..string.len()];
+    const bytes = string.asU8ptr()[0..string.len()];
     var iter = ReverseUtf8View.initUnchecked(bytes).iterator();
     while (iter.nextCodepoint()) |codepoint| {
         if (isWhitespace(codepoint)) {

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -4,7 +4,6 @@ platform "wasm-4"
         Task,
         W4,
         Sprite,
-
     ]
     packages {}
     imports [Task.{ Task }]

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -4,6 +4,7 @@ platform "wasm-4"
         Task,
         W4,
         Sprite,
+
     ]
     packages {}
     imports [Task.{ Task }]


### PR DESCRIPTION
# Changes
 
- Change non-mutated value declarations to use `const`, as `var` produces an error in Zig 0.12
- Replace calls to a few deprecated standard library functions.
- Update `build.zig` for compatibility with Zig 0.12. Use `addExecutable` instead of `addSharedLibrary` for WASM artifact.
- Update Roc module headers

Note: Glue files have been updated, but in the future the plan is to remove these from source control and generate them locally.