### PR TITLE
Add release workflow and refresh docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,18 +148,18 @@ jobs:
         run: |
           set -euo pipefail
           for _ in {1..30}; do
-            if curl --fail --silent --head "http://localhost:8000/$BUNDLE_NAME" > /dev/null; then
+            if curl --fail --silent --head "http://127.0.0.1:8000/$BUNDLE_NAME" > /dev/null; then
               exit 0
             fi
             sleep 1
           done
 
-          curl --fail --verbose --head "http://localhost:8000/$BUNDLE_NAME"
+          curl --fail --verbose --head "http://127.0.0.1:8000/$BUNDLE_NAME"
 
       - name: Rewrite examples to use platform bundle
         shell: bash
         env:
-          BUNDLE_URL: http://localhost:8000/${{ needs.build_and_bundle.outputs.bundle_name }}
+          BUNDLE_URL: http://127.0.0.1:8000/${{ needs.build_and_bundle.outputs.bundle_name }}
         run: |
           set -euo pipefail
           python3 - <<'PY'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,224 @@
+name: Release
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Tag to publish, for example v0.1.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+# this cancels workflows currently in progress if you start a new one
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  ZIG_VERSION: 0.16.0
+  ROC_VERSION: nightly-new-compiler
+
+jobs:
+  build_and_bundle:
+    name: build-and-bundle
+    runs-on: ubuntu-24.04
+    outputs:
+      bundle_name: ${{ steps.bundle.outputs.bundle_name }}
+      roc_version: ${{ steps.roc_version.outputs.roc_version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+
+      - name: Install Roc
+        uses: roc-lang/setup-roc@v0.2.0
+        with:
+          version: ${{ env.ROC_VERSION }}
+
+      - name: Capture Roc version
+        id: roc_version
+        shell: bash
+        run: |
+          set -euo pipefail
+          roc_version="$(roc version)"
+          echo "$roc_version"
+          {
+            echo "roc_version<<EOF"
+            echo "$roc_version"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build host object
+        run: zig build -Doptimize=ReleaseSafe
+
+      - name: Bundle platform
+        id: bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$(ROC=roc ./bundle.sh)"
+          printf '%s\n' "$output"
+
+          bundle_path="$(printf '%s\n' "$output" | sed -n 's/^Created: //p' | tail -n 1)"
+          if [ -z "$bundle_path" ]; then
+            echo "ERROR: Could not find bundle path in bundle.sh output" >&2
+            exit 1
+          fi
+
+          bundle_name="$(basename "$bundle_path")"
+          case "$bundle_name" in
+            *.tar.zst) ;;
+            *)
+              echo "ERROR: Expected a .tar.zst bundle, got $bundle_name" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ ! -f "$bundle_path" ]; then
+            echo "ERROR: Bundle does not exist: $bundle_path" >&2
+            exit 1
+          fi
+
+          echo "bundle_name=$bundle_name" >> "$GITHUB_OUTPUT"
+          echo "bundle_path=$bundle_path" >> "$GITHUB_OUTPUT"
+
+      - name: Upload platform bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: platform-bundle
+          path: ${{ steps.bundle.outputs.bundle_path }}
+          if-no-files-found: error
+
+  test_bundle:
+    name: test-bundle (${{ matrix.os }})
+    needs: build_and_bundle
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-15-intel
+          - macos-15
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - windows-2022
+          - windows-2025
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+
+      - name: Install Roc
+        uses: roc-lang/setup-roc@v0.2.0
+        with:
+          version: ${{ env.ROC_VERSION }}
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Download platform bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: platform-bundle
+          path: bundle
+
+      - name: Serve platform bundle
+        id: bundle_server
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m http.server 8000 --bind 127.0.0.1 --directory bundle &
+          echo "pid=$!" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for platform bundle
+        shell: bash
+        env:
+          BUNDLE_NAME: ${{ needs.build_and_bundle.outputs.bundle_name }}
+        run: |
+          set -euo pipefail
+          for _ in {1..30}; do
+            if curl --fail --silent --head "http://localhost:8000/$BUNDLE_NAME" > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          curl --fail --verbose --head "http://localhost:8000/$BUNDLE_NAME"
+
+      - name: Rewrite examples to use platform bundle
+        shell: bash
+        env:
+          BUNDLE_URL: http://localhost:8000/${{ needs.build_and_bundle.outputs.bundle_name }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          bundle_url = os.environ["BUNDLE_URL"]
+          old = '"../platform/main.roc"'
+          new = f'"{bundle_url}"'
+
+          for roc_file in sorted(Path("examples").glob("*.roc")):
+              text = roc_file.read_text()
+              if old not in text:
+                  raise SystemExit(f"ERROR: {roc_file} does not contain {old}")
+              roc_file.write_text(text.replace(old, new))
+          PY
+
+      - name: Test platform bundle
+        shell: bash
+        run: SKIP_ZIG_BUILD=1 ROC=roc ./ci/all_tests.sh
+
+      - name: Stop platform bundle server
+        if: always()
+        shell: bash
+        run: |
+          if [ -n "${{ steps.bundle_server.outputs.pid }}" ]; then
+            kill "${{ steps.bundle_server.outputs.pid }}" || true
+          fi
+
+  create_release:
+    name: create-release
+    if: github.event_name == 'workflow_dispatch'
+    needs:
+      - build_and_bundle
+      - test_bundle
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Download platform bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: platform-bundle
+          path: bundle
+
+      - name: Create GitHub release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          BUNDLE_NAME: ${{ needs.build_and_bundle.outputs.bundle_name }}
+          ROC_VERSION_ACTUAL: ${{ needs.build_and_bundle.outputs.roc_version }}
+          ZIG_VERSION_ACTUAL: ${{ env.ZIG_VERSION }}
+        run: |
+          set -euo pipefail
+          notes="Built with Zig $ZIG_VERSION_ACTUAL and $ROC_VERSION_ACTUAL."
+
+          gh release create "$RELEASE_TAG" "bundle/$BUNDLE_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$RELEASE_TAG" \
+            --generate-notes \
+            --notes "$notes"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,117 @@
+# Contributing
+
+This document is for roc-wasm4 platform development. If you are building a game with a released platform bundle, start with the [README](README.md).
+
+## Requirements
+
+- [Roc](https://www.roc-lang.org/install) new-compiler nightly, available as `roc`
+- [Zig](https://ziglang.org/download/) `0.16.0`
+- [WASM-4 CLI](https://wasm4.org), available as `w4`, for running and bundling carts
+- A Unix-like shell for `ci/all_tests.sh` and `bundle.sh`
+
+## Source Build
+
+Zig builds the wasm32 host object that lives at `platform/targets/wasm32/host.wasm`. Roc links that host object with an app when building a WASM-4 cart from the local platform path.
+
+```shell
+zig build
+roc build examples/snake.roc
+w4 run snake.wasm
+```
+
+Re-run `zig build` when changing host code or host build options such as `-Dmem-size=<bytes>`.
+
+## Local Checks
+
+Run the full local check suite with:
+
+```shell
+ROC=roc ./ci/all_tests.sh
+```
+
+This builds the Zig host, runs Zig tests, checks every Roc example and platform module, smoke-builds the example carts, generates docs, creates a local platform bundle, and runs platform Roc tests.
+
+`SKIP_ZIG_BUILD=1` is reserved for release validation. It skips local host builds, docs generation, and local bundling so rewritten examples can prove they build against a downloaded platform archive.
+
+## Local Examples
+
+The checked-in examples use:
+
+```roc
+w4: platform "../platform/main.roc"
+```
+
+That keeps local examples pointed at source changes. After `zig build`, run an example with:
+
+```shell
+roc build examples/basic.roc
+w4 run basic.wasm
+```
+
+## Documentation
+
+Generate platform API docs locally with:
+
+```shell
+zig build
+roc docs platform/main.roc --output=generated-docs
+python3 -m http.server 8000 --directory generated-docs
+```
+
+Then open `http://localhost:8000`.
+
+Docs are published by the `Generate docs` workflow when a GitHub Release is published.
+
+## Hot Reloading
+
+Hot reloading is useful while iterating, but it can break when state layout changes. One setup is to use [`entr`](https://github.com/eradman/entr):
+
+```shell
+find examples platform src \( -name "*.roc" -o -name "*.zig" \) \
+    | entr -ccr sh -c 'zig build && roc build examples/snake.roc'
+```
+
+In another terminal:
+
+```shell
+w4 run snake.wasm --hot
+```
+
+If hot reloading stops working, press `R` in the WASM-4 runtime to reload the cart.
+
+## Platform Bundles
+
+Package the platform as a Roc archive with:
+
+```shell
+zig build -Doptimize=ReleaseSafe
+ROC=roc ./bundle.sh
+```
+
+The bundle script writes a hash-named `.tar.zst` archive in the repository root and prints its path as `Created: ...`.
+
+## Release Workflow
+
+The `Release` workflow validates platform bundles before publishing:
+
+- On pull requests, it builds a bundle and tests examples against the downloaded archive on Linux, macOS, and Windows.
+- On manual dispatch with a `release_tag`, it creates a GitHub Release and attaches the generated `.tar.zst` archive.
+
+Use the exact `.tar.zst` asset URL from the GitHub Release in downstream apps:
+
+```roc
+app [main] {
+    w4: platform "https://github.com/lukewilliamboswell/roc-wasm4/releases/download/<tag>/<bundle>.tar.zst",
+}
+```
+
+## Game Distribution From Source
+
+When testing a game against a local platform checkout, build the host and Roc app with size-oriented optimizations:
+
+```shell
+zig build -Doptimize=ReleaseSmall
+roc build examples/snake.roc --opt=size
+```
+
+If the cart is too large, you can try lowering the dynamic memory space with `-Dmem-size=<bytes>`. The default is `40960` bytes.

--- a/README.md
+++ b/README.md
@@ -1,111 +1,121 @@
 # roc-wasm4
 
-Roc platform for the [wasm4](https://wasm4.org) game engine 🎮🕹️👾
+A Roc platform for building [WASM-4](https://wasm4.org) games.
 
-The intent for this platform is to have some fun, learn more about Roc and platform development, and contribute something for others to enjoy.
+roc-wasm4 gives Roc apps a high-level `W4` API for drawing, input, audio, disk persistence, netplay state, and sprites. Most apps should use a released roc-wasm4 platform bundle directly from GitHub Releases.
 
-### Setup
+## Requirements
 
-1. Clone this repository.
+- [Roc](https://www.roc-lang.org/install) new-compiler nightly, available as `roc`
+- [WASM-4 CLI](https://wasm4.org), available as `w4`
+- A roc-wasm4 `.tar.zst` platform bundle URL from the [GitHub Releases page](https://github.com/lukewilliamboswell/roc-wasm4/releases)
 
-2. Make sure you have the following in your `PATH` environment variable
-- [roc](https://www.roc-lang.org/install) new-compiler nightly,
-- [zig](https://ziglang.org/download/) version **0.16.0**
-- [w4](https://wasm4.org)
+## Quick Start
 
-### Run
+Create `app.roc` and point `platform` at a released `.tar.zst` bundle:
 
-Make the `zig wasm-ld` wrapper available and build the WASM-4 host object once:
+```roc
+app [main] {
+    w4: platform "https://github.com/lukewilliamboswell/roc-wasm4/releases/download/<tag>/<bundle>.tar.zst",
+}
 
-```shell
-export PATH="$PWD/scripts:$PATH"
-zig build
+import w4.W4
+
+Model : {}
+
+main = {
+    init!: || {},
+    update!: |model| {
+        W4.text!("Hello from Roc!", { x: 8, y: 8 })
+        model
+    },
+}
 ```
 
-Then build a game cart with Roc and run it with WASM-4:
+Build the cart and run it with WASM-4:
 
 ```shell
-roc build examples/snake.roc --target=wasm32
+roc build app.roc
+w4 run app.wasm
+```
+
+Because roc-wasm4 only declares a `wasm32` target, `roc build app.roc` defaults to writing `app.wasm`.
+
+For the native WASM-4 runtime, use `w4 run-native app.wasm`. Native can be much slower than the web runtime, especially for non-optimized builds.
+
+## Platform API
+
+The platform exposes:
+
+- `w4.W4` for WASM-4 drawing, input, audio, disk, random, and utility APIs
+- `w4.Sprite` for sprite data and blitting helpers
+- `w4.Host` for low-level hosted effects, mostly intended for platform internals
+
+Platform API docs are hosted at [lukewilliamboswell.github.io/roc-wasm4/](https://lukewilliamboswell.github.io/roc-wasm4/).
+
+## Examples
+
+This repository includes several example apps:
+
+- `examples/basic.roc`: drawing, text, input, mouse, trace, and tone basics
+- `examples/snake.roc`: a small playable snake game
+- `examples/rocci-bird.roc`: a Rocci Bird demo by Brendan Hansknecht with art by Luke DeVault
+- `examples/sound.roc`: a tone parameter playground
+
+The checked-in examples use the local platform path so contributors can test source changes. To use one as a starting point outside this repository, replace:
+
+```roc
+w4: platform "../platform/main.roc"
+```
+
+with a released bundle URL:
+
+```roc
+w4: platform "https://github.com/lukewilliamboswell/roc-wasm4/releases/download/<tag>/<bundle>.tar.zst"
+```
+
+Then build and run the app:
+
+```shell
+roc build snake.roc
 w4 run snake.wasm
 ```
 
-For the native WASM-4 runtime, use `w4 run-native snake.wasm`. Native can be much slower than web, especially for non-optimized builds.
-
-The `build.zig` script builds `platform/targets/wasm32/host.wasm`. Roc then links that host object with the app when you run `roc build <app>.roc --target=wasm32`.
-Re-run `zig build` when changing host code or host build options such as `-Dmem-size=<bytes>`.
-
-### Snake Demo
-
-- Unix/Macos `zig build && roc build examples/snake.roc --target=wasm32 && w4 run snake.wasm`
-- Windows `zig build && roc build .\examples\snake.roc --target=wasm32 && w4 run snake.wasm`
-
 ![snake demo](/examples/snake.gif)
 
-### Rocci-Bird Demo
-
-Thank you Brendan Hansknecht and Luke DeVault (art) for this demo.
-
-[Link to play online](https://bren077s.itch.io/rocci-bird)
-
-- Unix/Macos `zig build && roc build examples/rocci-bird.roc --target=wasm32 && w4 run rocci-bird.wasm`
-- Windows `zig build && roc build .\examples\rocci-bird.roc --target=wasm32 && w4 run rocci-bird.wasm`
+[Play Rocci Bird online](https://bren077s.itch.io/rocci-bird).
 
 ![rocci-bird demo](/examples/rocci-bird.gif)
 
-### Sound Demo
-
-- Unix/Macos `zig build && roc build examples/sound.roc --target=wasm32 && w4 run sound.wasm`
-- Windows `zig build && roc build .\examples\sound.roc --target=wasm32 && w4 run sound.wasm`
-
 ![sound demo](/examples/sound.gif)
 
-### Drum Roll
-
-Thank you Isaac Van Doren for this demo.
-
-[Link to source code](https://github.com/isaacvando/roc-drum-machine), and [play online](https://isaacvando.github.io/roc-drum-machine/)
+Drum Roll is a separate demo by Isaac Van Doren. [Source](https://github.com/isaacvando/roc-drum-machine) and [play online](https://isaacvando.github.io/roc-drum-machine/).
 
 ![drum roll](/examples/drum-roll.gif)
 
-### Documentation
+## Game Distribution
 
-📖 Platform docs hosted at [lukewilliamboswell.github.io/roc-wasm4/](https://lukewilliamboswell.github.io/roc-wasm4/)
-
-To generate locally use `roc docs platform/main.roc`, and then use a file server `simple-http-server generated-docs/`.
-
-### Hot Reloading
-
-Well it isn't perfect, hot reloading can be quite nice when developing a game. For this, I suggest using the [entr](https://github.com/eradman/entr) command line tool.
-
-In one terminal run the build command: `find . -name "*.roc" -o -name "*.zig" | entr -ccr sh -c 'zig build && roc build examples/snake.roc --target=wasm32'`.
-
-In another terminal run wasm4: `w4 run snake.wasm --hot`.
-
-If the hot reloading breaks (which it often does when changing the data layout or state), simply press `R` to reload the cart.
-
-### Distribution
-
-To release a game, first build the host with optimizations and then build the Roc app for size:
+For a smaller game cart, build the Roc app with size-oriented optimizations:
 
 ```shell
-zig build -Doptimize=ReleaseSmall
-roc build examples/snake.roc --target=wasm32 --opt=size
+roc build app.roc --opt=size
 ```
 
-Then bundle it [like any other wasm4 game](https://wasm4.org/docs/guides/distribution/) using the generated cartridge, for example `snake.wasm`.
-If your cartridge is too large, you can try lowering the dynamic memory space with `-Dmem-size=<size>`. The default is `40960` bytes.
+Bundle the generated cart with the WASM-4 CLI:
 
-For example, a web release can be built with:
 ```shell
-w4 bundle snake.wasm --title "My Game" --html my-game.html
+w4 bundle app.wasm --title "My Game" --html my-game.html
 ```
 
-For windows/mac/linux, a bundling command could look like:
+For native bundles:
+
 ```shell
-w4 bundle snake.wasm --title "My Game" \
+w4 bundle app.wasm --title "My Game" \
     --windows my-game-windows.exe \
     --mac my-game-mac \
     --linux my-game-linux
 ```
 
-To package this platform as a Roc archive, run `zig build && ./bundle.sh`. It writes a `.tar.zst` file in the repository root.
+## Contributing
+
+Source-build setup, local checks, docs generation, and release maintenance are covered in [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/ci/all_tests.sh
+++ b/ci/all_tests.sh
@@ -32,10 +32,6 @@ mkdir -p "$BUILD_DIR"
 mkdir -p "$ROC_CACHE_DIR"
 export ROC_CACHE_DIR
 
-# Roc's wasm linker path invokes `wasm-ld` directly. Zig ships it as
-# `zig wasm-ld`, so put our small wrapper on PATH for local runs and CI.
-export PATH="$PWD/scripts:$PATH"
-
 echo "Roc: $("$ROC_BIN" version)"
 echo "Zig: $(zig version)"
 

--- a/ci/all_tests.sh
+++ b/ci/all_tests.sh
@@ -26,6 +26,7 @@ EXAMPLES_DIR='./examples/'
 PLATFORM_DIR='./platform/'
 BUILD_DIR="${BUILD_DIR:-.zig-cache/roc-wasm4-ci}"
 ROC_CACHE_DIR="${ROC_CACHE_DIR:-$PWD/$BUILD_DIR/roc-cache}"
+SKIP_ZIG_BUILD="${SKIP_ZIG_BUILD:-0}"
 
 mkdir -p "$BUILD_DIR"
 mkdir -p "$ROC_CACHE_DIR"
@@ -39,10 +40,18 @@ echo "Roc: $("$ROC_BIN" version)"
 echo "Zig: $(zig version)"
 
 # host object
-zig build
+if [ "$SKIP_ZIG_BUILD" = "1" ]; then
+    echo "Skipping zig build because SKIP_ZIG_BUILD=1"
+else
+    zig build
+fi
 
 # zig tests
-zig build test
+if [ "$SKIP_ZIG_BUILD" = "1" ]; then
+    echo "Skipping zig build test because SKIP_ZIG_BUILD=1"
+else
+    zig build test
+fi
 
 # roc check
 for roc_file in "$EXAMPLES_DIR"*.roc; do
@@ -62,10 +71,18 @@ for roc_file in "$EXAMPLES_DIR"*.roc; do
 done
 
 # test building docs website
-"$ROC_BIN" docs platform/main.roc --output="$BUILD_DIR/generated-docs"
+if [ "$SKIP_ZIG_BUILD" = "1" ]; then
+    echo "Skipping local docs generation because SKIP_ZIG_BUILD=1"
+else
+    "$ROC_BIN" docs platform/main.roc --output="$BUILD_DIR/generated-docs"
+fi
 
 # test packaging the platform archive
-ROC="$ROC_BIN" ./bundle.sh
+if [ "$SKIP_ZIG_BUILD" = "1" ]; then
+    echo "Skipping local platform bundling because SKIP_ZIG_BUILD=1"
+else
+    ROC="$ROC_BIN" ./bundle.sh
+fi
 
 # roc tests
 "$ROC_BIN" test platform/W4.roc

--- a/platform/Sprite.roc
+++ b/platform/Sprite.roc
@@ -4,7 +4,7 @@
 ## or 2 bits per pixel (`BPP2`), along with information about how to read the
 ## pixel data.
 ##
-## [Refer w4 docs for more information](https://wasm4.org/docs/guides/sprites)
+## [Refer to the WASM-4 docs for more information](https://wasm4.org/docs/guides/sprites)
 import Host
 
 ## Represents a [sprite](https://en.wikipedia.org/wiki/Sprite_(computer_graphics))
@@ -48,7 +48,7 @@ Sprite := {
     ## Sprite.blit!(fruit_sprite, { x: 0, y: 0, flags: [FlipX, Rotate] })
     ## ```
     ##
-    ## [Refer w4 docs for more information](https://wasm4.org/docs/reference/functions#blit-spriteptr-x-y-width-height-flags)
+    ## [Refer to the WASM-4 docs for more information](https://wasm4.org/docs/reference/functions#blit-spriteptr-x-y-width-height-flags)
     blit! : Sprite, { x : I32, y : I32, flags : List([FlipX, FlipY, Rotate]) } => {}
     blit! = |sprite, { x, y, flags }| {
         { src_x, src_y, width, height } = sprite.region

--- a/platform/W4.roc
+++ b/platform/W4.roc
@@ -1,6 +1,6 @@
 ## # roc-wasm4
 ##
-## Build [wasm4](https://wasm4.org) games using Roc.
+## Build [WASM-4](https://wasm4.org) games using Roc.
 ##
 ## This module provides the high-level, ergonomic API for the WASM-4 platform.
 ## Internally it wraps the low-level effects exposed by `Host`.
@@ -197,7 +197,7 @@ W4 :: [].{
     ## Text color is the Primary draw color.
     ## Background color is the Secondary draw color.
     ##
-    ## [Refer w4 docs for more information](https://wasm4.org/docs/guides/text)
+    ## [Refer to the WASM-4 docs for more information](https://wasm4.org/docs/guides/text)
     text! : Str, { x : I32, y : I32 } => {}
     text! = |str, { x, y }| Host.text!(str, x, y)
 
@@ -210,7 +210,7 @@ W4 :: [].{
     ## Fill color is the Primary draw color.
     ## Border color is the Secondary draw color.
     ##
-    ## [Refer w4 docs for more information](https://wasm4.org/docs/reference/functions#rect-x-y-width-height)
+    ## [Refer to the WASM-4 docs for more information](https://wasm4.org/docs/reference/functions#rect-x-y-width-height)
     rect! : { x : I32, y : I32, width : U32, height : U32 } => {}
     rect! = |{ x, y, width, height }| Host.rect!(x, y, width, height)
 
@@ -223,7 +223,7 @@ W4 :: [].{
     ## Fill color is the Primary draw color.
     ## Border color is the Secondary draw color.
     ##
-    ## [Refer w4 docs for more information](https://wasm4.org/docs/reference/functions#oval-x-y-width-height)
+    ## [Refer to the WASM-4 docs for more information](https://wasm4.org/docs/reference/functions#oval-x-y-width-height)
     oval! : { x : I32, y : I32, width : U32, height : U32 } => {}
     oval! = |{ x, y, width, height }| Host.oval!(x, y, width, height)
 
@@ -235,7 +235,7 @@ W4 :: [].{
     ##
     ## Line color is the Primary draw color.
     ##
-    ## [Refer w4 docs for more information](https://wasm4.org/docs/reference/functions#line-x1-y1-x2-y2)
+    ## [Refer to the WASM-4 docs for more information](https://wasm4.org/docs/reference/functions#line-x1-y1-x2-y2)
     line! : { x : I32, y : I32 }, { x : I32, y : I32 } => {}
     line! = |{ x: x1, y: y1 }, { x: x2, y: y2 }| Host.line!(x1, y1, x2, y2)
 
@@ -329,7 +329,7 @@ W4 :: [].{
     ##
     ## Note: All WASM-4 games that support local multiplayer automatically support netplay.
     ##
-    ## [Refer w4 docs for more information](https://wasm4.org/docs/guides/multiplayer)
+    ## [Refer to the WASM-4 docs for more information](https://wasm4.org/docs/guides/multiplayer)
     get_netplay! : () => Netplay
     get_netplay! = || {
         flags = Host.get_netplay!()
@@ -384,7 +384,7 @@ W4 :: [].{
     ## W4.trace!("Hello, World")
     ## ```
     ##
-    ## [Refer w4 docs for more information](https://wasm4.org/docs/guides/trace)
+    ## [Refer to the WASM-4 docs for more information](https://wasm4.org/docs/guides/trace)
     trace! : Str => {}
     trace! = |str| Host.trace!(str)
 
@@ -402,7 +402,7 @@ W4 :: [].{
     ##
     ## Games can persist up to 1024 bytes of data.
     ##
-    ## [Refer w4 docs for more information](https://wasm4.org/docs/guides/diskw)
+    ## [Refer to the WASM-4 docs for more information](https://wasm4.org/docs/guides/diskw)
     save_to_disk! : List(U8) => Try({}, [SaveFailed])
     save_to_disk! = |data|
         if Host.disk_write!(data) {
@@ -419,7 +419,7 @@ W4 :: [].{
     ##
     ## Games can persist up to 1024 bytes of data.
     ##
-    ## [Refer w4 docs for more information](https://wasm4.org/docs/guides/diskw)
+    ## [Refer to the WASM-4 docs for more information](https://wasm4.org/docs/guides/diskw)
     load_from_disk! : () => List(U8)
     load_from_disk! = || Host.disk_read!()
 
@@ -479,10 +479,10 @@ W4 :: [].{
 
     ## Plays a tone sound.
     ##
-    ## Please refer to the [wasm4 audio docs](https://wasm4.org/docs/guides/audio/).
+    ## Please refer to the [WASM-4 audio docs](https://wasm4.org/docs/guides/audio/).
     ##
     ## The sound.roc example app along with the
-    ## [wasm4 sound tools](https://wasm4.org/docs/guides/audio/#sound-tool) can be
+    ## [WASM-4 sound tools](https://wasm4.org/docs/guides/audio/#sound-tool) can be
     ## quite helpful to play with.
     tone! :
         {

--- a/scripts/wasm-ld
+++ b/scripts/wasm-ld
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-exec "${ZIG:-zig}" wasm-ld "$@"


### PR DESCRIPTION
## Summary
- add a Release workflow that builds a platform bundle, validates downloaded-bundle consumption across supported runners, and creates releases on manual dispatch
- refresh README for the released-platform-bundle user flow
- move source-build, local checks, docs, and release maintenance notes into CONTRIBUTING.md
- remove the stale scripts/wasm-ld wrapper and references

## Testing
- git diff --check origin/main...release-workflow
- previous PR run passed build-and-bundle, test-bundle on macOS/Linux/Windows, and test-examples after switching bundle URLs to 127.0.0.1
- locally built a ReleaseSafe platform bundle, served it over HTTP, built the README quick-start app against it, and manually launched the checked-in examples with w4

## Notes
- This is the same release/docs work from #34, rebased onto main because #34 was accidentally merged into upgrade-zig-compiler after #33 had already merged that branch into main.
- During manual QA, examples/sound.roc exposed upstream Roc compiler/runtime issues around wasm list refcount callbacks and LLVM List.set lowering. Those fixes are in a local Roc checkout, not in this roc-wasm4 branch yet.