### PR TITLE
Update platform for latest Roc main

### DIFF
--- a/examples/basic.roc
+++ b/examples/basic.roc
@@ -1,4 +1,4 @@
-app [main] { w4: platform "https://github.com/lukewilliamboswell/roc-wasm4/releases/download/0.5/sZGj6cG7ted2RNohpqvQwqb7pvBd5C5zotA5XXyJZnA.tar.zst" }
+app [main] { w4: platform "../platform/main.roc" }
 
 import w4.W4
 

--- a/examples/rocci-bird.roc
+++ b/examples/rocci-bird.roc
@@ -1,5 +1,5 @@
 app [main] {
-    w4: platform "https://github.com/lukewilliamboswell/roc-wasm4/releases/download/0.5/sZGj6cG7ted2RNohpqvQwqb7pvBd5C5zotA5XXyJZnA.tar.zst",
+    w4: platform "../platform/main.roc",
 }
 
 import w4.W4
@@ -127,7 +127,7 @@ GameState : {
 }
 
 initGame! : TitleScreenState => Model
-initGame! = |{ frameCount, plants }| {
+initGame! = |{ frameCount, plants, .. }| {
     # Seed the randomness with number of frames since the start of the game.
     # This makes the game feel like it is truely randomly seeded cause players won't always start on the same frame.
     saveRandToDisk!(frameCount)
@@ -215,7 +215,7 @@ runGame! = |prev| {
     plants =
         appendIfOk(updatePlants(prev.plants), plant)
 
-    gainPoint = U64.to_u8_wrap(List.count_if(prev.pipes, |{ x }| x == playerX - 2))
+    gainPoint = U64.to_u8_wrap(List.count_if(prev.pipes, |{ x, .. }| x == playerX - 2))
     y = prev.player.y + yVel
     score = U8.plus_saturated(prev.score, gainPoint)
     state = { ..prev,
@@ -276,7 +276,7 @@ GameOverState : {
 }
 
 initGameOver! : GameState => Model
-initGameOver! = |{ frameCount, maxScore, score, player, pipes, plants, groundX }| {
+initGameOver! = |{ frameCount, maxScore, score, player, pipes, plants, groundX, .. }| {
     hs = loadHighScoreFromDisk!()
     newHighScore = maxScore > hs
     highScore =
@@ -653,7 +653,7 @@ updateAnimation : U64, Animation -> Animation
 updateAnimation = |frameCount, anim| {
     framesPerUpdate =
         match List.get(anim.cells, anim.index) {
-            Ok({ frames }) => frames
+            Ok({ frames, .. }) => frames
             Err(_) => { crash "animation cell out of bounds at index: ${U64.to_str(anim.index)}" }
         }
 
@@ -681,7 +681,7 @@ updateAnimation = |frameCount, anim| {
 drawAnimation! : Animation, { x : I32, y : I32, flags : List([FlipX, FlipY, Rotate]) } => {}
 drawAnimation! = |anim, { x, y, flags }|
     match List.get(anim.cells, anim.index) {
-        Ok({ sprite }) => {
+        Ok({ sprite, .. }) => {
             setSpriteColors!()
             Sprite.blit!(sprite, { x, y, flags })
         }
@@ -700,7 +700,7 @@ wrappedInc = |val, count| {
 }
 
 idleShift : U64, Animation -> I32
-idleShift = |frameCount, { index, lastUpdated }|
+idleShift = |frameCount, { index, lastUpdated, .. }|
     if index == 2 {
         0
     } else if index == 1 and frameCount - lastUpdated > 3 {
@@ -722,7 +722,7 @@ createRocciIdleAnim = |frameCount| {
 }
 
 flapAllowed : U64, Animation -> Bool
-flapAllowed = |frameCount, { index, lastUpdated }|
+flapAllowed = |frameCount, { index, lastUpdated, .. }|
     if index == 2 {
         Bool.True
     } else if index == 1 {

--- a/examples/snake.roc
+++ b/examples/snake.roc
@@ -1,5 +1,5 @@
 app [main] {
-    w4: platform "https://github.com/lukewilliamboswell/roc-wasm4/releases/download/0.5/sZGj6cG7ted2RNohpqvQwqb7pvBd5C5zotA5XXyJZnA.tar.zst",
+    w4: platform "../platform/main.roc",
 }
 
 import w4.W4
@@ -163,7 +163,7 @@ draw_snake_head! = |snake| {
 }
 
 update_snake : Snake, GamepadState, U64, Fruit -> (Snake, [AteFruit, DidNotEat])
-update_snake = |s0, { left, right, up, down }, frame_count, fruit| {
+update_snake = |s0, { left, right, up, down, .. }, frame_count, fruit| {
     s1 =
         if left and !right {
             { ..s0, direction: Left }
@@ -222,10 +222,10 @@ grow_snake = |{ head, body, direction }| {
 }
 
 snake_is_dead : Snake -> Bool
-snake_is_dead = |{ head, body }| List.contains(body, head)
+snake_is_dead = |{ head, body, .. }| List.contains(body, head)
 
 get_random_fruit! : Snake => Fruit
-get_random_fruit! = |{ head, body }| {
+get_random_fruit! = |{ head, body, .. }| {
     var $fruit = head
     var $done = Bool.False
 

--- a/examples/sound.roc
+++ b/examples/sound.roc
@@ -1,5 +1,5 @@
 app [main] {
-    w4: platform "https://github.com/lukewilliamboswell/roc-wasm4/releases/download/0.5/sZGj6cG7ted2RNohpqvQwqb7pvBd5C5zotA5XXyJZnA.tar.zst",
+    w4: platform "../platform/main.roc",
 }
 
 import w4.W4

--- a/platform/Sprite.roc
+++ b/platform/Sprite.roc
@@ -7,6 +7,17 @@
 ## [Refer to the WASM-4 docs for more information](https://wasm4.org/docs/guides/sprites)
 import Host
 
+BlitTransform : [FlipX, FlipY, Rotate]
+
+# Keep flag bit computation outside the effectful opaque method until roc-lang/roc#9749 is fixed.
+blitTransformFlags : List(BlitTransform) -> U32
+blitTransformFlags = |flags| {
+    flip_x_bit = if flags.contains(FlipX) { 2 } else { 0 }
+    flip_y_bit = if flags.contains(FlipY) { 4 } else { 0 }
+    rotate_bit = if flags.contains(Rotate) { 8 } else { 0 }
+    flip_x_bit + flip_y_bit + rotate_bit
+}
+
 ## Represents a [sprite](https://en.wikipedia.org/wiki/Sprite_(computer_graphics))
 ## for drawing to the screen.
 Sprite := {
@@ -49,7 +60,7 @@ Sprite := {
     ## ```
     ##
     ## [Refer to the WASM-4 docs for more information](https://wasm4.org/docs/reference/functions#blit-spriteptr-x-y-width-height-flags)
-    blit! : Sprite, { x : I32, y : I32, flags : List([FlipX, FlipY, Rotate]) } => {}
+    blit! : Sprite, { x : I32, y : I32, flags : List(BlitTransform) } => {}
     blit! = |sprite, { x, y, flags }| {
         { src_x, src_y, width, height } = sprite.region
 
@@ -58,11 +69,7 @@ Sprite := {
             BPP2 => 1
         }
 
-        # Each flag occupies a distinct bit, so we can sum non-duplicate contributions.
-        flip_x_bit = if flags.contains(FlipX) { 2 } else { 0 }
-        flip_y_bit = if flags.contains(FlipY) { 4 } else { 0 }
-        rotate_bit = if flags.contains(Rotate) { 8 } else { 0 }
-        combined = format + flip_x_bit + flip_y_bit + rotate_bit
+        combined = format + blitTransformFlags(flags)
 
         Host.blit_sub!(sprite.data, x, y, width, height, src_x, src_y, sprite.stride, combined)
     }

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -34,7 +34,7 @@ platform ""
         "host_vline": Host.vline!,
     }
     targets: {
-        inputs: "targets/",
+        inputs_dir: "targets/",
         wasm32: {
             inputs: ["host.wasm", app],
             output: Shared,

--- a/src/roc_platform_abi.zig
+++ b/src/roc_platform_abi.zig
@@ -97,9 +97,48 @@ pub fn increfBox(data_ptr: ?*anyopaque, amount: isize) void {
     _ = @atomicRmw(isize, rc, .Add, amount, .monotonic);
 }
 
+/// Allocate a Roc box and return a pointer to its payload data.
+pub fn allocateBox(
+    payload_size: usize,
+    payload_alignment: usize,
+    payload_contains_refcounted: bool,
+    roc_host: *RocHost,
+) *anyopaque {
+    const ptr_width = @sizeOf(usize);
+    const required_space: usize = if (payload_contains_refcounted) (2 * ptr_width) else ptr_width;
+    const header_bytes = @max(required_space, payload_alignment);
+    const alloc_alignment = @max(ptr_width, payload_alignment);
+    const base: [*]u8 = @ptrCast(roc_host.roc_alloc(roc_host, header_bytes + payload_size, alloc_alignment));
+    const data = base + header_bytes;
+    const rc: *isize = @ptrFromInt(@intFromPtr(data) - @sizeOf(isize));
+    rc.* = 1;
+    return @ptrCast(data);
+}
+
 /// Decrement a pointer-aligned boxed payload with no Roc refcounted values.
 pub fn decrefBox(data_ptr: ?*anyopaque, roc_host: *RocHost) void {
     decrefBoxWith(data_ptr, @alignOf(usize), null, roc_host);
+}
+
+/// Increment a boxed function closure.
+pub fn increfErasedCallable(callable: RocErasedCallable, amount: isize) void {
+    const data = callable orelse return;
+    increfBox(@ptrCast(data), amount);
+}
+
+/// Decrement a boxed function closure and run its capture drop callback on final release.
+pub fn decrefErasedCallable(callable: RocErasedCallable, roc_host: *RocHost) void {
+    const data = callable orelse return;
+    decrefBoxWith(@ptrCast(data), roc_erased_callable_payload_alignment, &dropErasedCallablePayload, roc_host);
+}
+
+fn dropErasedCallablePayload(data_ptr: ?*anyopaque, roc_host: *RocHost) callconv(.c) void {
+    const data = data_ptr orelse return;
+    const callable: RocErasedCallable = @ptrCast(data);
+    const payload = rocErasedCallablePayloadPtr(callable);
+    if (payload.on_drop) |on_drop| {
+        on_drop(rocErasedCallableCapturePtr(callable), roc_host);
+    }
 }
 
 /// Decrement a boxed payload and run payload teardown when this is the final ref.
@@ -321,6 +360,14 @@ pub fn RocListWith(comptime T: type, comptime elements_refcounted: bool) type {
             return &[_]T{};
         }
 
+        /// Return every initialized element in the backing allocation.
+        pub fn allocationItems(self: Self) []const T {
+            const alloc_ptr = self.getAllocationPtr() orelse return &[_]T{};
+            const count = self.allocationElementCount();
+            const ptr: [*]const T = @ptrCast(@alignCast(alloc_ptr));
+            return ptr[0..count];
+        }
+
         /// Return the number of elements in the list.
         pub fn len(self: Self) usize {
             return self.length;
@@ -352,6 +399,15 @@ pub fn RocListWith(comptime T: type, comptime elements_refcounted: bool) type {
             }
             const ptr = self.elements_ptr orelse return null;
             return @ptrCast(ptr);
+        }
+
+        fn allocationElementCount(self: Self) usize {
+            if (self.isSeamlessSlice() and elements_refcounted) {
+                const alloc_ptr = self.getAllocationPtr() orelse return 0;
+                const ptr: [*]const usize = @ptrCast(@alignCast(alloc_ptr));
+                return (ptr - 2)[0];
+            }
+            return self.length;
         }
 
         /// Allocate a new list with space for `length` elements.
@@ -408,6 +464,13 @@ pub fn RocListWith(comptime T: type, comptime elements_refcounted: bool) type {
             if (rc.* == 0) return true; // REFCOUNT_STATIC_DATA — treated as unique
             return rc.* == 1;
         }
+
+        /// Return true if this list's allocation has exactly one counted ref.
+        pub fn hasOneRef(self: Self) bool {
+            const alloc_ptr = self.getAllocationPtr() orelse return false;
+            const rc: *const isize = @ptrFromInt(@intFromPtr(alloc_ptr) - @sizeOf(isize));
+            return rc.* == 1;
+        }
     };
 }
 
@@ -458,7 +521,7 @@ pub const RocIo = struct {
     }
 
     fn nativeWriteStderr(_: ?*anyopaque, data: []const u8) void {
-        std.fs.File.stderr().writeAll(data) catch {};
+        std.Io.File.stderr().writeStreamingAll(std.Io.Threaded.global_single_threaded.io(), data) catch {};
     }
 
     fn nativeOnFatal(_: ?*anyopaque) noreturn {
@@ -688,6 +751,22 @@ pub const HostVlineArgs = extern struct {
     arg1: i32,
     arg2: u32,
 };
+
+// =============================================================================
+// Generated Refcount Helpers
+// =============================================================================
+
+/// Recursively decrement Roc-owned fields in __AnonStruct10.
+pub fn decref__AnonStruct10(value: __AnonStruct10, roc_host: *RocHost) void {
+    _ = value;
+    _ = roc_host;
+}
+
+/// Increment Roc-owned fields in __AnonStruct10.
+pub fn incref__AnonStruct10(value: __AnonStruct10, amount: isize) void {
+    _ = value;
+    _ = amount;
+}
 
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- update the platform header for latest Roc `main` (`inputs_dir`)
- regenerate Zig glue with Roc `debug-ad55d522`
- point examples at the local platform and update record patterns required by current Roc
- move sprite blit flag-bit computation out of the effectful opaque method as a workaround for roc-lang/roc#9749

## Validation

- `ROC=roc ./ci/all_tests.sh`
- `zig build test`
- `zig build`
- `roc build examples/rocci-bird.roc --target=wasm32 --output=/tmp/rocci-bird.wasm --no-cache`

Compiler issue filed while reducing the panic: https://github.com/roc-lang/roc/issues/9749
